### PR TITLE
implementacion de SharedPreferences para el orden de los eventos y re…

### DIFF
--- a/app/src/main/java/com/example/earthquakemonitor/main/MainViewModel.kt
+++ b/app/src/main/java/com/example/earthquakemonitor/main/MainViewModel.kt
@@ -11,7 +11,7 @@ import java.net.UnknownHostException
 
 private val TAG = MainViewModel::class.java.simpleName
 
-class MainViewModel(application: Application) : AndroidViewModel(application) {
+class MainViewModel(application: Application, private val sortType: Boolean) : AndroidViewModel(application) {
     private val _status = MutableLiveData<ApiStatusResponse>()
     val status: LiveData<ApiStatusResponse>
         get() = _status
@@ -24,7 +24,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     get() = _eqList
 
     init {
-        reloadEartquakes(false)
+        reloadEartquakes(sortType)
     }
 
     fun reloadEartquakes(sortByMagnitude: Boolean) {

--- a/app/src/main/java/com/example/earthquakemonitor/main/MainViewModelFactory.kt
+++ b/app/src/main/java/com/example/earthquakemonitor/main/MainViewModelFactory.kt
@@ -5,8 +5,8 @@ import android.view.View
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 
-class MainViewModelFactory (private val application: Application) : ViewModelProvider.Factory {
+class MainViewModelFactory (private val application: Application, private val sortType: Boolean) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create (modelClass: Class<T>): T {
-        return MainViewModel(application) as T
+        return MainViewModel(application, sortType) as T
     }
 }


### PR DESCRIPTION
Implementacion del SharedPreferences para guardar el orden que se le da a los terremotos:
![image](https://github.com/MatiBarth/udemyEarthQuakeMonitor/assets/97895340/a0d4716b-81a7-406c-b483-6a670e762689)


Refactorizacion del codigo  en la "Rueda de progreso". Se elimina codigo repetitivo para cada una de las instancias en la que puede estar la aplicacion si es que no esta cargando:
![image](https://github.com/MatiBarth/udemyEarthQuakeMonitor/assets/97895340/6405b09b-4964-4bef-a069-2f698f7a7808)
